### PR TITLE
refactor(webcomponents): add "isActionButtonCell" to HeaderProps

### DIFF
--- a/packages/local-components-test/src/Home.tsx
+++ b/packages/local-components-test/src/Home.tsx
@@ -1,21 +1,158 @@
 /* eslint-disable no-console */
-import { Dropdownbutton, Button } from '@rws-air/webcomponents';
-import React, { FC } from 'react';
-import CloudDownload from '@material-ui/icons/CloudDownload';
-import { Grid } from '@material-ui/core';
+import TableRow from '@material-ui/core/TableRow';
+import { Table, TableBodyCell, TableProps } from '@rws-air/webcomponents';
+import React, { FC, Fragment } from 'react';
+import css from 'styles/modules/app.module.scss';
+import SearchIcon from '@material-ui/icons/Search';
+import { IconButton } from '@material-ui/core';
+import DeleteIcon from '@material-ui/icons/Delete';
 
-const options = [ 'short', 'Create merge commit', 'Squash and merge', 'This is a very long option that should produce a very long button because it has a lot of characters in a very long sentence' ];
+interface DataForTableType {
+  name: string;
+  email: string;
+  id: number;
+}
+
+const dataForTable: DataForTableType[] = [
+  { name: 'Robin Hood', email: 'robin.hood@winked.com', id: 23456789 },
+  { name: 'Steve Jobs', email: 'steve.jobs@apple.com', id: 1 },
+  { name: 'Darth Vader', email: 'darth.vader@thedeathstart.com', id: 9876 },
+  { name: 'Kaladin Stormblessed', email: 'kaladin.stormblessed@thearmy.com', id: 567890 },
+  { name: 'John Geary', email: 'john.geary@thelostfleet.com', id: 567890 },
+  { name: 'Robin Hood', email: 'robin.hood@winked.com', id: 23456789 },
+  { name: 'Steve Jobs', email: 'steve.jobs@apple.com', id: 1 },
+  { name: 'Steve Jobs', email: 'steve.jobs@apple.com', id: 1 },
+  { name: 'Darth Vader', email: 'darth.vader@thedeathstart.com', id: 9876 },
+  { name: 'Steve Jobs', email: 'steve.jobs@apple.com', id: 1 },
+  { name: 'Kaladin Stormblessed', email: 'kaladin.stormblessed@thearmy.com', id: 567890 },
+  { name: 'Steve Jobs', email: 'steve.jobs@apple.com', id: 1 },
+  { name: 'Robin Hood', email: 'robin.hood@winked.com', id: 23456789 },
+  { name: 'Steve Jobs', email: 'steve.jobs@apple.com', id: 1 },
+  { name: 'Darth Vader', email: 'darth.vader@thedeathstart.com', id: 9876 }
+];
+
+const dataTableHeaderMapping: Map<string, string> = new Map(
+  [
+    [
+      'id', 'id'
+    ],
+    [
+      'name', 'name'
+    ],
+    [
+      'email', 'email'
+    ],
+    [
+      'action', 'action'
+    ]
+  ]
+);
+
+const rowsPerPage = 5;
+const page = 0;
+
+const propsForTable: TableProps = {
+  onsearchclear: () => console.log('cleared the search'),
+  onsearchinput: () => console.log('got some search input'),
+  onRequestSort: () => console.log('A sort was requested'),
+  tooltipplacement: 'top',
+  order: 'asc',
+  orderby: 'name',
+  rowsPerPage,
+  rowsPerPageOptions: [ 2, 4, 5, 10 ],
+  page,
+  onChangePage: () => console.log('changed page'),
+  onChangeRowsPerPage: () => console.log('changed rows per page'),
+  headers: [
+    { label: Array.from(dataTableHeaderMapping.keys())[0], numeric: true },
+    { label: Array.from(dataTableHeaderMapping.keys())[1] },
+    { label: Array.from(dataTableHeaderMapping.keys())[2] },
+    { label: Array.from(dataTableHeaderMapping.keys())[3], isActionButtonCell: true }
+  ],
+  headermapping: dataTableHeaderMapping,
+  rowcount: dataForTable.length,
+  labels: {
+    labelPaginationOf: 'of',
+    labelRowsPerPage: 'Rows per page',
+    searchplaceholderlabel: 'Search...',
+    tooltiplabel: 'Sorteren',
+  },
+  tableqas: {
+    header: 'table-header',
+    headerRow: 'table-header-row',
+    pagination: 'table-pagination',
+    table: 'table',
+    toolbar: 'table-toolbar',
+    headerCell: 'table-header-cell',
+    tableBody: 'table-body',
+  },
+  tablebodycontent: (
+    <Fragment>
+      {dataForTable
+        .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+        .map(row => (
+          <TableRow hover tabIndex={-1} key={Math.random()} className={css.tableRow} data-qa='sample-table-body-row' >
+            <TableBodyCell content={row.name} />
+            <TableBodyCell content={row.email} />
+            <TableBodyCell content={row.id} />
+            <TableBodyCell
+              content={
+                <IconButton
+                  onClick={undefined}
+                  data-qa='edit-user-button'
+                  color='primary'
+                >
+                  <DeleteIcon />
+                </IconButton>
+              }
+            />
+          </TableRow>
+        ))
+      }
+    </Fragment>
+  ),
+  tablecss: {
+    table: [ css.customTable, css.customTable ],
+    tableToolbar: [ css.customTableToolbar ],
+  },
+  paperElevation: 1,
+  showBottomPagination: true,
+  showTopPagination: true,
+  extraIcons: [
+    {
+      icon: <SearchIcon className={css.svgIcon} />,
+      clickEvent: () => console.log('void'),
+      disabled: true,
+    },
+    {
+      icon: <SearchIcon className={css.svgIcon} />,
+      clickEvent: () => console.log('void'),
+    },
+    {
+      icon: <SearchIcon className={css.svgIcon} />,
+      clickEvent: () => console.log('void'),
+    },
+    {
+      icon: <SearchIcon className={css.svgIcon} />,
+      clickEvent: () => console.log('void'),
+    },
+    {
+      icon: <SearchIcon className={css.svgIcon} />,
+      clickEvent: () => console.log('void'),
+    },
+    {
+      icon: <SearchIcon className={css.svgIcon} />,
+      clickEvent: () => console.log('void'),
+    }
+  ],
+};
+
 
 const Home: FC = () => {
   return (
-    <Grid container direction='row'>
-      <Grid item style={{ marginRight: '1%', width: '30vw' }}>
-        <Dropdownbutton options={options} ButtonIcon={<CloudDownload />} onClick={(prop: string) => console.log('I am clicked', prop)} />
-      </Grid>
-      <Grid item style={{ marginRight: '1%' }}>
-        <Button fullWidth variant='contained' color='primary' onClick={() => undefined} label='test' />
-      </Grid>
-    </Grid>
+    <Fragment>
+      <Table {...propsForTable} />
+    </Fragment>
   );
 };
 

--- a/packages/webcomponents/__tests__/Table.test.tsx
+++ b/packages/webcomponents/__tests__/Table.test.tsx
@@ -19,15 +19,28 @@ const dataForTable: DataForTableType[] = [
   { name: 'Steve Jobs', email: 'steve.jobs@apple.com', id: 1 }
 ];
 
-const dataTableHeaderMapping: Map<string, string> = new Map()
-  .set('name', 'name')
-  .set('email', 'email')
-  .set('id', 'id');
+const dataTableHeaderMapping: Map<string, string> = new Map(
+  [
+    [
+      'name', 'name'
+    ],
+    [
+      'email', 'email'
+    ],
+    [
+      'id', 'id'
+    ],
+    [
+      'action', 'action'
+    ]
+  ]
+);
 
 const tableHeaders: TableHeaderProps[] = [
   { label: Array.from(dataTableHeaderMapping.keys())[0] },
   { label: Array.from(dataTableHeaderMapping.keys())[1] },
-  { label: Array.from(dataTableHeaderMapping.keys())[2], numeric: true }
+  { label: Array.from(dataTableHeaderMapping.keys())[2], numeric: true },
+  { label: Array.from(dataTableHeaderMapping.keys())[3], isActionButtonCell: true }
 ];
 
 const rowsPerPage = 5;
@@ -87,15 +100,35 @@ const propsForTable: TableProps = {
 describe('Component Tests', () => {
   let table: ShallowWrapper;
 
-  beforeAll(() => {
+  beforeEach(() => {
     table = shallow(<Table {...propsForTable} />);
   });
 
+  afterEach(() => {
+    mockOnRequestSort.mockRestore();
+    mockOnSearchInput.mockRestore();
+    mockOnSearchClear.mockRestore();
+    mockOnChangePage.mockRestore();
+    mockOnChangeRowsPerPage.mockRestore();
+  });
+
   test('should request sorting on header click', () => {
-    const tableSortHeader = table.find(TableHeaderCell).at(0).shallow().find(`[data-qa="tableSortLabel_${tableHeaders[0].label}"]`);
+    const firstColumnHeaderCell = table.find(TableHeaderCell).at(0).shallow();
+    const tableSortHeader = firstColumnHeaderCell.find(`[data-qa="tableSortLabel_${tableHeaders[0].label}"]`);
+
     tableSortHeader.simulate('click');
+
     expect(mockOnRequestSort).toHaveBeenCalledWith('name');
     expect(mockOnRequestSort).toHaveBeenCalledTimes(1);
+  });
+
+  test('should not request sorting on action header click', () => {
+    const lastColumnHeaderCell = table.find(TableHeaderCell).last().shallow();
+    const tableSortHeader = lastColumnHeaderCell.find(`[data-qa="tableSortLabel_${tableHeaders[3].label}"]`);
+
+    tableSortHeader.simulate('click');
+
+    expect(mockOnRequestSort).toHaveBeenCalledTimes(0);
   });
 
   describe('Table Headers', () => {
@@ -110,7 +143,7 @@ describe('Component Tests', () => {
 
       const firstRow = table.find('[data-qa="table-header-row"]').first();
       const tableHeaderCell = firstRow.find(TableHeaderCell).first().shallow().find(`[data-qa="tableSortLabel_${tableHeaders[0].label}"]`);
-      expect(firstRow.find(TableHeaderCell)).toHaveLength(3);
+      expect(firstRow.find(TableHeaderCell)).toHaveLength(4);
       expect(tableHeaderCell.render().text()).toBe(tableHeaders[0].label);
 
       // Restore console errors

--- a/packages/webcomponents/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/packages/webcomponents/__tests__/__snapshots__/Table.test.tsx.snap
@@ -50,21 +50,7 @@ exports[`Snapshot Testing Optional Props 1`] = `
             }
           }
           key="name"
-          onRequestSort={
-            [MockFunction] {
-              "calls": Array [
-                Array [
-                  "name",
-                ],
-              ],
-              "results": Array [
-                Object {
-                  "type": "return",
-                  "value": undefined,
-                },
-              ],
-            }
-          }
+          onRequestSort={[MockFunction]}
           order="asc"
           orderby="name"
           tooltiplabel="Sort"
@@ -79,21 +65,7 @@ exports[`Snapshot Testing Optional Props 1`] = `
             }
           }
           key="email"
-          onRequestSort={
-            [MockFunction] {
-              "calls": Array [
-                Array [
-                  "name",
-                ],
-              ],
-              "results": Array [
-                Object {
-                  "type": "return",
-                  "value": undefined,
-                },
-              ],
-            }
-          }
+          onRequestSort={[MockFunction]}
           order="asc"
           orderby="name"
           tooltiplabel="Sort"
@@ -109,21 +81,24 @@ exports[`Snapshot Testing Optional Props 1`] = `
             }
           }
           key="id"
-          onRequestSort={
-            [MockFunction] {
-              "calls": Array [
-                Array [
-                  "name",
-                ],
-              ],
-              "results": Array [
-                Object {
-                  "type": "return",
-                  "value": undefined,
-                },
-              ],
+          onRequestSort={[MockFunction]}
+          order="asc"
+          orderby="name"
+          tooltiplabel="Sort"
+          tooltipplacement="bottom-start"
+        />
+        <Memo(TableHeaderCell)
+          customclasses=""
+          data-qa="table-header-cell"
+          header={
+            Object {
+              "isActionButtonCell": true,
+              "label": "action",
             }
           }
+          isActionButtonCell={true}
+          key="action"
+          onRequestSort={[MockFunction]}
           order="asc"
           orderby="name"
           tooltiplabel="Sort"
@@ -254,21 +229,7 @@ exports[`Snapshot Testing Required Props 1`] = `
             }
           }
           key="name"
-          onRequestSort={
-            [MockFunction] {
-              "calls": Array [
-                Array [
-                  "name",
-                ],
-              ],
-              "results": Array [
-                Object {
-                  "type": "return",
-                  "value": undefined,
-                },
-              ],
-            }
-          }
+          onRequestSort={[MockFunction]}
           order="asc"
           orderby="name"
           tooltiplabel="Sort"
@@ -283,21 +244,7 @@ exports[`Snapshot Testing Required Props 1`] = `
             }
           }
           key="email"
-          onRequestSort={
-            [MockFunction] {
-              "calls": Array [
-                Array [
-                  "name",
-                ],
-              ],
-              "results": Array [
-                Object {
-                  "type": "return",
-                  "value": undefined,
-                },
-              ],
-            }
-          }
+          onRequestSort={[MockFunction]}
           order="asc"
           orderby="name"
           tooltiplabel="Sort"
@@ -313,21 +260,24 @@ exports[`Snapshot Testing Required Props 1`] = `
             }
           }
           key="id"
-          onRequestSort={
-            [MockFunction] {
-              "calls": Array [
-                Array [
-                  "name",
-                ],
-              ],
-              "results": Array [
-                Object {
-                  "type": "return",
-                  "value": undefined,
-                },
-              ],
+          onRequestSort={[MockFunction]}
+          order="asc"
+          orderby="name"
+          tooltiplabel="Sort"
+          tooltipplacement="bottom-start"
+        />
+        <Memo(TableHeaderCell)
+          customclasses=""
+          data-qa="table-header-cell"
+          header={
+            Object {
+              "isActionButtonCell": true,
+              "label": "action",
             }
           }
+          isActionButtonCell={true}
+          key="action"
+          onRequestSort={[MockFunction]}
           order="asc"
           orderby="name"
           tooltiplabel="Sort"

--- a/packages/webcomponents/package.json
+++ b/packages/webcomponents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rws-air/webcomponents",
-  "version": "8.1.1",
+  "version": "8.1.2",
   "description": "Standard Webcomponents for AIR projects",
   "author": "@rws-air",
   "license": "AGPL-3.0-or-later",

--- a/packages/webcomponents/src/Table/Table.tsx
+++ b/packages/webcomponents/src/Table/Table.tsx
@@ -140,6 +140,7 @@ export const Table: FC<TableProps> = props => {
                 onRequestSort={props.onRequestSort}
                 data-qa={props.tableqas.headerCell}
                 customclasses={classnames(addCustomClasses('tableHeaderCell'))}
+                isActionButtonCell={header.isActionButtonCell}
               />
             ))}
           </TableRow>

--- a/packages/webcomponents/src/TableHeaderCell/TableHeaderCell.tsx
+++ b/packages/webcomponents/src/TableHeaderCell/TableHeaderCell.tsx
@@ -2,9 +2,9 @@ import MUITableCell, { TableCellProps as MUITableCellProps } from '@material-ui/
 import TableSortLabel from '@material-ui/core/TableSortLabel';
 import classnames from 'classnames';
 import React, { FC, memo } from 'react';
-import css from './TableHeaderCell.scss';
-import Tooltip, { TooltipProps } from '../Tooltip/Tooltip';
 import { customCss, dataQa, label } from '../constants';
+import Tooltip, { TooltipProps } from '../Tooltip/Tooltip';
+import css from './TableHeaderCell.scss';
 
 export interface TableHeaderProps {
   /** Label for this table header */
@@ -13,6 +13,8 @@ export interface TableHeaderProps {
   numeric?: boolean;
   /** Whether the additional padding for this table header should be disabled */
   disablePadding?: boolean;
+  /** Whether this header is for a cell that contains an action button */
+  isActionButtonCell?: boolean;
 }
 
 export interface TableHeaderCellProps extends MUITableCellProps {
@@ -32,29 +34,52 @@ export interface TableHeaderCellProps extends MUITableCellProps {
   'data-qa'?: dataQa;
   /** Custom CSS classes to pass to the button */
   customclasses?: customCss;
+  /** Whether this header is for a cell that contains an action button */
+  isActionButtonCell?: boolean;
 }
 
 /** Creates a table header cell using pre-defined Rijkswaterstaat styling */
-export const TableHeaderCell: FC<TableHeaderCellProps> = props => (
-  <MUITableCell
-    data-qa={props['data-qa']}
-    align={props.header.numeric ? 'right' : 'left'}
-    padding={props.header.disablePadding ? 'none' : 'default'}
-    sortDirection={props.orderby === props.header.label ? props.order : false}
-    className={classnames(css.tableCells, props.customclasses)}>
-    <Tooltip title={props.tooltiplabel} placement={props.tooltipplacement || 'top'}
-      data-qa={`table-header-${props['data-qa']}`}>
-      <TableSortLabel
-        data-qa={`tableSortLabel_${props.header.label}`}
-        classes={{icon: css.sortIcon}}
-        active={props.orderby === props.header.label}
-        direction={props.order}
-        onClick={() => props.onRequestSort(props.header.label)}
-      >
-        {props.header.label}
-      </TableSortLabel>
-    </Tooltip>
-  </MUITableCell>
-);
+export const TableHeaderCell: FC<TableHeaderCellProps> = props => {
+  const renderTableHeaderCell = () => {
+    if (props.isActionButtonCell) {
+      return (
+        <TableSortLabel
+          data-qa={`tableSortLabel_${props.header.label}`}
+          active={false}
+          hideSortIcon
+          onClick={() => undefined}
+        >
+          {props.header.label}
+        </TableSortLabel>
+      );
+    }
+
+    return (
+      <Tooltip title={props.tooltiplabel} placement={props.tooltipplacement || 'top'}
+        data-qa={`table-header-${props['data-qa']}`}>
+        <TableSortLabel
+          data-qa={`tableSortLabel_${props.header.label}`}
+          classes={{icon: css.sortIcon}}
+          active={props.orderby === props.header.label}
+          direction={props.order}
+          onClick={() => props.onRequestSort(props.header.label)}
+        >
+          {props.header.label}
+        </TableSortLabel>
+      </Tooltip>
+    );
+  };
+
+  return (
+    <MUITableCell
+      data-qa={props['data-qa']}
+      align={props.header.numeric ? 'right' : 'left'}
+      padding={props.header.disablePadding ? 'none' : 'default'}
+      sortDirection={props.orderby === props.header.label ? props.order : false}
+      className={classnames(css.tableCells, props.customclasses)}>
+      {renderTableHeaderCell()}
+    </MUITableCell>
+  );
+};
 
 export default memo(TableHeaderCell);


### PR DESCRIPTION
This prop will disable sorting and activating the header cell, to be used for columns that only have a button to perform some action

**Monorepo Management**
- My changes affect:
  - [ ] eslint-config
  - [ ] jestscreenshot
  - [ ] local-components-test
  - [ ] stylelint-config
  - [ ] tslint-config
  - [ ] user-creator
  - [ ] utils
  - [x] webcomponents

**Status**
- [x] Code changes have been tested against my own code, or there are no code changes