### PR TITLE
chore: remove vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "up": "yarn upgrade-interactive --latest",
     "scripts:runner": "ts-node -P tsconfig.eslint.json",
     "scripts:validateNoOnly": "yarn scripts:runner scripts/validateNoOnly",
-    "scripts:yarnAfterPull": "yarn scripts:runner scripts/yarnAfterPull",
-    "now.sh": "yarn ci:build && yarn docs && rm -rf packages scripts node_modules .git-authors"
+    "scripts:yarnAfterPull": "yarn scripts:runner scripts/yarnAfterPull"
   },
   "devDependencies": {
     "@babel/core": "^7.10.2",


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Vercel (aka now.sh) has changed their pricing setup and now forces teams
to pay 15 USD per member, rather than providing a free option.

They have been bugging me about this for a while now
through emails and rather than coughing up the money I think it is
better to just disable the service.

Assigned this high priority lest they start forcing me to pay despite not providing them with a payment method.

Note: Vercel step failed in checks because of the very change made in this PR.

---

What you guys also want to do is follow these steps, @jeroenmies and I think also @mpehenssen can do those.

1. Go to https://github.com/RWS-NL
2. Click "Settings", screenshot taken for my own team:
![image](https://user-images.githubusercontent.com/4019718/86952521-69d16b80-c153-11ea-8a28-9ddc32369a7f.png)
3. Go to "Installed GitHub Apps"
![image](https://user-images.githubusercontent.com/4019718/86952547-75249700-c153-11ea-8fb0-83d6e44c70a7.png)
4. At the line that says "Vercel" (black and white icon) click the "Configure" button
(screenshot taken for a different app as I already uninstalled it for myself)
![image](https://user-images.githubusercontent.com/4019718/86952738-b87f0580-c153-11ea-87b0-cdf02270f52b.png)

5. Scroll to the bottom of the page then click "Uninstall"
![image](https://user-images.githubusercontent.com/4019718/86952806-d2204d00-c153-11ea-8820-711201d39f82.png)


Once you've done this please let me know and I will delete the team on the Vercel side of things.